### PR TITLE
add application.properties file so piwik works when this jar is used

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+cdn.url=//${CDN_HOST}
+piwik.url=${PIWIK_URL}
+piwik.siteId=${PIWIK_SITE_ID}


### PR DESCRIPTION
Not having the application.properties file in the project meant that when used as a dependency in another project it could not resolve the piwik.js URL. Adding this file fixes the problem and allows piwik to work.