### PR TITLE
Adds cookie consent fragment, including optional piwik

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,7 @@ publish:
 .PHONY: sonar
 sonar:
 	mvn sonar:sonar
+
+.PHONY: sonar-pr-analysis
+sonar-pr-analysis:
+	mvn sonar:sonar -P sonar-pr-analysis

--- a/src/main/resources/templates/fragments/piwikWithCookieCheck.html
+++ b/src/main/resources/templates/fragments/piwikWithCookieCheck.html
@@ -13,7 +13,7 @@
           <a href="">cookies to collect information</a>
           about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.</p>
         <a class="govuk-button govuk-!-margin-right-3" th:onclick="acceptCookies()">Accept all cookies</a>
-        <a th:onclick="rejectCookies()" class="govuk-button">Reject all Cookies</a>
+        <a th:onclick="rejectCookies()" class="govuk-button">Reject all optional cookies</a>
       </div>
     </div>
   </div>

--- a/src/main/resources/templates/fragments/piwikWithCookieCheck.html
+++ b/src/main/resources/templates/fragments/piwikWithCookieCheck.html
@@ -5,16 +5,16 @@
 </head>
 <body>
 <div th:fragment="cookieBanner">
-  <div class="govuk-cookie-banner " role="region" aria-label="Cookies on Companies House services">
-    <div id="cookie-banner" class="govuk-cookie-banner__message govuk-width-container">
+  <div class="govuk-cookie-banner" role="region" aria-label="Cookies on Companies House services">
+    <div id="cookie-banner" class="govuk-cookie-banner__message govuk-width-container" hidden>
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on Companies House services</h2>
 
           <div class="govuk-cookie-banner__content">
-            <p>We use some essential cookies to make this service work.</p>
-            <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+            <p>We use some essential cookies to make our services work.</p>
+            <p>We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.</p>
           </div>
         </div>
       </div>
@@ -35,7 +35,7 @@
         <div class="govuk-grid-column-two-thirds">
 
           <div class="govuk-cookie-banner__content">
-            <p>You’ve accepted analytics cookies. You can <a href="#">change your cookie settings</a> at any time.</p>
+            <p>You’ve accepted analytics cookies. You can <a th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">change your cookie settings</a> at any time.</p>
           </div>
         </div>
       </div>

--- a/src/main/resources/templates/fragments/piwikWithCookieCheck.html
+++ b/src/main/resources/templates/fragments/piwikWithCookieCheck.html
@@ -19,7 +19,7 @@
         </div>
       </div>
       <div class="govuk-button-group">
-        <button th:onclick="CookieConsent.acceptCookies()" type="button" class="govuk-button" data-module="govuk-button">
+        <button th:onclick="CookieConsent.acceptCookies(startPiwik)" type="button" class="govuk-button" data-module="govuk-button">
           Accept analytics cookies
         </button>
         <button th:onclick="CookieConsent.rejectCookies()" type="button" class="govuk-button" data-module="govuk-button">

--- a/src/main/resources/templates/fragments/piwikWithCookieCheck.html
+++ b/src/main/resources/templates/fragments/piwikWithCookieCheck.html
@@ -62,7 +62,7 @@
           <div class="ch-cookie-grid-column-two-thirds">
             <h2 class="ch-cookie-cookie-banner__heading ch-cookie-heading-m">Cookies on Companies House services</h2>
             <div class="ch-cookie-cookie-banner__content">
-              <p class="ch-cookie-body">We use cookies to make our services work and collect analytics information. To accept or reject cookies, turn on JavaScript in your browser settings and reload this page.</p>
+              <p class="ch-cookie-body">We use cookies to make our services work and collect analytics information. To accept or reject analytics cookies, turn on JavaScript in your browser settings and reload this page.</p>
             </div>
           </div>
         </div>

--- a/src/main/resources/templates/fragments/piwikWithCookieCheck.html
+++ b/src/main/resources/templates/fragments/piwikWithCookieCheck.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>Piwik</title>
+</head>
+<body>
+<div id="cookie-banner" th:fragment="cookieBanner">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-heading-m">Tell us whether you accept cookies</p>
+        <p>We use
+          <a href="">cookies to collect information</a>
+          about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.</p>
+        <a class="govuk-button govuk-!-margin-right-3" th:onclick="acceptCookies()">Accept all cookies</a>
+        <a th:onclick="rejectCookies()" class="govuk-button">Reject all Cookies</a>
+      </div>
+    </div>
+  </div>
+</div>
+<div th:fragment="piwikWithCookieCheck" class="govuk-visually-hidden">
+  <script th:inline="javascript">
+      function startPiwik() {
+          bindPiwikListener([[${moduleName}]], /*[[${@environment.getProperty('piwik.url')}]]*/, /*[[${@environment.getProperty('piwik.siteId')}]]*/);
+      }
+  </script>
+  <noscript>
+    <p>
+      <img th:src="@{{piwikUrl}/piwik.php?idsite={siteId}(piwikUrl=${@environment.getProperty('piwik.url')},
+                             siteId=${@environment.getProperty('piwik.site.id')})}" style="border:0;" alt="" />
+    </p>
+  </noscript>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/piwikWithCookieCheck.html
+++ b/src/main/resources/templates/fragments/piwikWithCookieCheck.html
@@ -11,8 +11,8 @@
         <p class="govuk-heading-m">Cookies on Companies House services</p>
         <p>We use some essential cookies to make our services work.</p>
         <p>We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.</p>
-        <a class="govuk-button govuk-!-margin-right-3" th:onclick="acceptCookies()">Accept analytics cookies</a>
-        <a class="govuk-button govuk-!-margin-right-3" th:onclick="rejectCookies()">Reject analytics cookies</a>
+        <a class="govuk-button govuk-!-margin-right-3" th:onclick="CookieConsent.acceptCookies()">Accept analytics cookies</a>
+        <a class="govuk-button govuk-!-margin-right-3" th:onclick="CookieConsent.rejectCookies()">Reject analytics cookies</a>
         <a th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">View cookies</a>
       </div>
     </div>

--- a/src/main/resources/templates/fragments/piwikWithCookieCheck.html
+++ b/src/main/resources/templates/fragments/piwikWithCookieCheck.html
@@ -5,13 +5,11 @@
 </head>
 <body>
 <div th:fragment="cookieBanner">
-  <div class="govuk-cookie-banner" role="region" aria-label="Cookies on Companies House services">
-    <div id="cookie-banner" class="govuk-cookie-banner__message govuk-width-container" hidden>
-
+  <div id="cookie-banner" class="govuk-cookie-banner" role="region" aria-label="Cookies on Companies House services" hidden>
+    <div id="accept-or-reject-message" class="govuk-cookie-banner__message govuk-width-container" hidden>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on Companies House services</h2>
-
           <div class="govuk-cookie-banner__content">
             <p>We use some essential cookies to make our services work.</p>
             <p>We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.</p>
@@ -19,29 +17,39 @@
         </div>
       </div>
       <div class="govuk-button-group">
-        <button th:onclick="CookieConsent.acceptCookies(startPiwik)" type="button" class="govuk-button" data-module="govuk-button">
+        <button id="accept-cookies-button" type="button" class="govuk-button" data-module="govuk-button">
           Accept analytics cookies
         </button>
-        <button th:onclick="CookieConsent.rejectCookies()" type="button" class="govuk-button" data-module="govuk-button">
+        <button id="reject-cookies-button" type="button" class="govuk-button" data-module="govuk-button">
           Reject analytics cookies
         </button>
-        <a class="govuk-link" th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">View cookies</a>
+        <a class="govuk-link" href="{{ chs.url }}/help/cookies">View cookies</a>
       </div>
     </div>
-
-    <div id="govuk-cookie-banner__message" class="govuk-cookie-banner__message govuk-width-container" role="alert" hidden>
-
+    <div id="accepted-cookies-message" class="govuk-cookie-banner__message govuk-width-container" role="alert" hidden>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-
           <div class="govuk-cookie-banner__content">
-            <p>You’ve accepted analytics cookies. You can <a th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">change your cookie settings</a> at any time.</p>
+            <p>You've accepted analytics cookies. You can <a href="{{ chs.url }}/help/cookies">change your cookie settings</a> at any time.</p>
           </div>
         </div>
       </div>
-
       <div class="govuk-button-group">
-        <button th:onclick="CookieConsent.hideBannerAlert()" class="govuk-button" data-module="govuk-button">
+        <button id="hide-accepted-message-button" class="govuk-button" data-module="govuk-button">
+          Hide this message
+        </button>
+      </div>
+    </div>
+    <div id="rejected-cookies-message" class="govuk-cookie-banner__message govuk-width-container" role="alert" hidden>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-cookie-banner__content">
+            <p>You've rejected analytics cookies. You can <a href="{{ chs.url }}/help/cookies">change your cookie settings</a> at any time.</p>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        <button id="hide-rejected-message-button" class="govuk-button" data-module="govuk-button">
           Hide this message
         </button>
       </div>

--- a/src/main/resources/templates/fragments/piwikWithCookieCheck.html
+++ b/src/main/resources/templates/fragments/piwikWithCookieCheck.html
@@ -8,12 +8,12 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-heading-m">Tell us whether you accept cookies</p>
-        <p>We use
-          <a href="">cookies to collect information</a>
-          about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.</p>
-        <a class="govuk-button govuk-!-margin-right-3" th:onclick="acceptCookies()">Accept all cookies</a>
-        <a th:onclick="rejectCookies()" class="govuk-button">Reject all optional cookies</a>
+        <p class="govuk-heading-m">Cookies on Companies House services</p>
+        <p>We use some essential cookies to make our services work.</p>
+        <p>We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.</p>
+        <a class="govuk-button govuk-!-margin-right-3" th:onclick="acceptCookies()">Accept analytics cookies</a>
+        <a class="govuk-button govuk-!-margin-right-3" th:onclick="rejectCookies()">Reject analytics cookies</a>
+        <a th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">View cookies</a>
       </div>
     </div>
   </div>

--- a/src/main/resources/templates/fragments/piwikWithCookieCheck.html
+++ b/src/main/resources/templates/fragments/piwikWithCookieCheck.html
@@ -30,7 +30,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="govuk-cookie-banner__content">
-            <p>You've accepted analytics cookies. You can <a href="{{ chs.url }}/help/cookies">change your cookie settings</a> at any time.</p>
+            <p>You've accepted analytics cookies. You can <a class="govuk-link" href="{{ chs.url }}/help/cookies">change your cookie settings</a> at any time.</p>
           </div>
         </div>
       </div>
@@ -44,7 +44,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="govuk-cookie-banner__content">
-            <p>You've rejected analytics cookies. You can <a href="{{ chs.url }}/help/cookies">change your cookie settings</a> at any time.</p>
+            <p>You've rejected analytics cookies. You can <a class="govuk-link" href="{{ chs.url }}/help/cookies">change your cookie settings</a> at any time.</p>
           </div>
         </div>
       </div>
@@ -55,18 +55,19 @@
       </div>
     </div>
   </div>
-</div>
-<div th:fragment="piwikWithCookieCheck" class="govuk-visually-hidden">
-  <script th:inline="javascript">
-      function startPiwik() {
-          bindPiwikListener([[${moduleName}]], /*[[${@environment.getProperty('piwik.url')}]]*/, /*[[${@environment.getProperty('piwik.siteId')}]]*/);
-      }
-  </script>
   <noscript>
-    <p>
-      <img th:src="@{{piwikUrl}/piwik.php?idsite={siteId}(piwikUrl=${@environment.getProperty('piwik.url')},
-                             siteId=${@environment.getProperty('piwik.site.id')})}" style="border:0;" alt="" />
-    </p>
+    <div class="ch-cookie-cookie-banner" role="region" aria-label="Cookies on Companies House services">
+      <div class="ch-cookie-cookie-banner__message ch-cookie-width-container">
+        <div class="ch-cookie-grid-row">
+          <div class="ch-cookie-grid-column-two-thirds">
+            <h2 class="ch-cookie-cookie-banner__heading ch-cookie-heading-m">Cookies on Companies House services</h2>
+            <div class="ch-cookie-cookie-banner__content">
+              <p class="ch-cookie-body">We use cookies to make our services work and collect analytics information. To accept or reject cookies, turn on JavaScript in your browser settings and reload this page.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </noscript>
 </div>
 </body>

--- a/src/main/resources/templates/fragments/piwikWithCookieCheck.html
+++ b/src/main/resources/templates/fragments/piwikWithCookieCheck.html
@@ -4,16 +4,46 @@
   <title>Piwik</title>
 </head>
 <body>
-<div id="cookie-banner" th:fragment="cookieBanner">
-  <div class="govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-heading-m">Cookies on Companies House services</p>
-        <p>We use some essential cookies to make our services work.</p>
-        <p>We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.</p>
-        <a class="govuk-button govuk-!-margin-right-3" th:onclick="CookieConsent.acceptCookies()">Accept analytics cookies</a>
-        <a class="govuk-button govuk-!-margin-right-3" th:onclick="CookieConsent.rejectCookies()">Reject analytics cookies</a>
-        <a th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">View cookies</a>
+<div th:fragment="cookieBanner">
+  <div class="govuk-cookie-banner " role="region" aria-label="Cookies on Companies House services">
+    <div id="cookie-banner" class="govuk-cookie-banner__message govuk-width-container">
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on Companies House services</h2>
+
+          <div class="govuk-cookie-banner__content">
+            <p>We use some essential cookies to make this service work.</p>
+            <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        <button th:onclick="CookieConsent.acceptCookies()" type="button" class="govuk-button" data-module="govuk-button">
+          Accept analytics cookies
+        </button>
+        <button th:onclick="CookieConsent.rejectCookies()" type="button" class="govuk-button" data-module="govuk-button">
+          Reject analytics cookies
+        </button>
+        <a class="govuk-link" th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">View cookies</a>
+      </div>
+    </div>
+
+    <div id="govuk-cookie-banner__message" class="govuk-cookie-banner__message govuk-width-container" role="alert" hidden>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+          <div class="govuk-cookie-banner__content">
+            <p>You’ve accepted analytics cookies. You can <a href="#">change your cookie settings</a> at any time.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="govuk-button-group">
+        <button th:onclick="CookieConsent.hideBannerAlert()" class="govuk-button" data-module="govuk-button">
+          Hide this message
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Part of 3 PR's that make up the PoC for Cookie Consent in CHS. The other PR's are in cdn.ch.gov.uk and the example implementation can be found in lfp-pay-web.

This PR adds 2 fragments. 1 that contains the cookie banner. 1 that contains a function that is called from the javascript on the page that starts Piwik. If no consent, piwik doesn't run.

