### PR TITLE
Remove `/api/docs/` from developer site link

### DIFF
--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -11,7 +11,7 @@
                         <li><a id="policies-link" href="http://resources.companieshouse.gov.uk/serviceInformation.shtml">Policies</a></li>
                         <li><a id="cookies-link" th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">Cookies</a></li>
                         <li><a id="contact-us-link" th:href="@{{chsUrl}/help/contact-us(chsUrl=${@environment.getProperty('chs.url')})}">Contact us</a></li>
-                        <li><a id="developer-link" th:href="@{{developerUrl}/api/docs/(developerUrl=${@environment.getProperty('developer.url')})}">Developers</a></li>
+                        <li><a id="developer-link" th:href="@{{developerUrl}(developerUrl=${@environment.getProperty('developer.url')})}">Developers</a></li>
                     </ul>
                 </div>
             </nav>


### PR DESCRIPTION
This is a tentative PR to confirm that we should remove `/api/docs/` from the link in the CHS footer to the developer site.

The developer site has changed (in last few months?)

So this resolves: https://developer.cidev.aws.chdev.org
this does not: https://developer.cidev.aws.chdev.org/api/docs/

Though having said that in staging and live, there's some redirect so that, even if `/api/docs/` is included, it navigates to the developer site