### PR TITLE
CC-1333: Use correct favicon logo

### DIFF
--- a/src/main/resources/templates/layouts/chsBaseLayout.html
+++ b/src/main/resources/templates/layouts/chsBaseLayout.html
@@ -20,7 +20,7 @@
             media="all" rel="stylesheet" type="text/css" />
     <link
             rel="icon"
-            th:href="@{{cdnUrl}/images/favicon.ico?0.17.3(cdnUrl=${@environment.getProperty('cdn.url')})}"
+            th:href="@{{cdnUrl}/images/govuk-frontend/v4.6.0/images/favicon.ico(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="image/x-icon" />
     <link
             th:href="@{{cdnUrl}/stylesheets/extensions/languages-nav.css(cdnUrl=${@environment.getProperty('cdn.url')})}"


### PR DESCRIPTION
__Short description outlining key changes/additions__

* Change the favicon logo brought in by the base layout to match that previously used in the Perl code.

__JIRA Ticket Number__

* [CC-1333](https://companieshouse.atlassian.net/browse/CC-1333)

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure Change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

### Wrong logo

![cc-1333 wrong logo](https://github.com/companieshouse/common-web-java/assets/54801196/f4980ffb-7eb0-42c7-9c71-32ff7e47225d)

### Right logo

![cc-1333 right logo](https://github.com/companieshouse/common-web-java/assets/54801196/1e913322-ccd8-47e0-975e-cc97c3b5e854)



[CC-1333]: https://companieshouse.atlassian.net/browse/CC-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ