### PR TITLE
Mark current language to bring in appropriate padding

### DIFF
--- a/src/main/resources/templates/fragments/addLangToUrl.html
+++ b/src/main/resources/templates/fragments/addLangToUrl.html
@@ -10,7 +10,7 @@
     <a th:unless="${locale == lang}" th:href="${url} + '?' + ${queryParams} + ${lang}" th:hreflang=${lang} rel="alternate" class="govuk-link">
       <span th:text=${displayLang}></span>
     </a>
-    <span th:if="${locale == lang}" th:text=${displayLang}></span>
+    <span aria-current="true" th:if="${locale == lang}" th:text=${displayLang}></span>
 
   </span>
 </th:block>


### PR DESCRIPTION
Currently if English is the selected language it is squashed up against the separator like this "English| Cymraeg".
Adding the 'aria-current="true"' attribute applies a padding space so that it looks like "English | Cymraeg".
The padding that is applied can be seen [here](https://github.com/companieshouse/cdn.ch.gov.uk/blob/master/app/assets/stylesheets/extensions/languages-nav.css#L62-L64)