### PR TITLE
add condition on base layout for welsh translation

### DIFF
--- a/src/main/resources/templates/layouts/chsBaseLayout.html
+++ b/src/main/resources/templates/layouts/chsBaseLayout.html
@@ -53,7 +53,7 @@
             <div th:replace="~{fragments/back-button :: backLink}"></div>
             <div th:replace="~{fragments/userBar :: userBar}"></div>
             <div th:replace="~{fragments/adminSearch :: adminSearch}"></div>
-            <div th:if="${@environment.getProperty('welshLanguage.enabled')}">
+            <div th:if="${@environment.getProperty('welshLanguage.enabled') or #httpServletRequest.getAttribute('onWelshJourney')}">
                 <div th:replace="~{fragments/localesBanner :: localesBanner}"></div>
             </div>
             <main id="content" role="main" class="govuk-main-wrapper app-main-class">


### PR DESCRIPTION
Added this condition for the welsh translation journey in the common shared services. Specifically this was added to allow the Company-Lookup-Web service to use the base layout and still persist the welsh translations when on coming from a journey that is welsh translation enabled. 