### PR TITLE
[2699] Upgrade dependencies to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,16 @@
     <properties>
         <java.version>21</java.version>
         <thymeleaf-layout-dialect.version>3.3.0</thymeleaf-layout-dialect.version>
-        <spring-boot-dependencies.version>3.3.12</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.3.7</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.4.8</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.4.8</spring-boot-maven-plugin.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
-        <structured-logging.version>3.0.21</structured-logging.version>
+        <structured-logging.version>3.0.37</structured-logging.version>
+        <commons.lang3.version>3.18.0</commons.lang3.version>
+        <logback.version>1.5.15</logback.version>
+        <snakeyaml.version>2.2</snakeyaml.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <junit-jupiter-engine.version>5.10.5</junit-jupiter-engine.version>
         <sonar.projectName>common-web-java</sonar.projectName>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.host.url>${CODE_ANALYSIS_HOST_URL}</sonar.host.url>
@@ -76,12 +80,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.15</version>
+            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.15</version>
+            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -90,7 +94,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>2.2</version>
+            <version>${snakeyaml.version}</version>
         </dependency>
 
         <dependency>
@@ -102,9 +106,20 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-simple</artifactId>
                 </exclusion>
+                <!-- Excluding to address CVE-2025-48924. commons-lang3-3.17.0 is pulled transitively-->
+                <exclusion>
+                   <groupId>org.apache.commons</groupId>
+                   <artifactId>commons-lang3</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
+        <!-- included to address CVE-2025-48924-->
+        <dependency>
+           <groupId>org.apache.commons</groupId>
+           <artifactId>commons-lang3</artifactId>
+           <version>${commons.lang3.version}</version>
+       </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -123,6 +138,12 @@
             <version>${sonar-maven-plugin.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter-engine.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -133,15 +154,8 @@
                     <environmentVariables>
                     </environmentVariables>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <groupId>org.junit.platform</groupId>
-                        <version>${junit-platform-surefire-provider.version}</version>
-                    </dependency>
-                </dependencies>
                 <groupId>org.apache.maven.plugins</groupId>
-                <version>2.22.2</version>
+                <version>${maven-surefire-plugin.version}</version>
             </plugin>
             <plugin>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
 - Replaced hard-coded versions in dependencies with property references
 - excluded commons-lang3 to resolve CVE-2025-48924
 - removed deprecated junit-platform-surefire-provider provider in plugin configuration
 - added junit-jupiter-engine dependency
 - Bumped the following dependencies
   - spring-boot-dependencies version to 3.4.8 to resolve CVE-2025-41234,CVE-2025-49124
   - spring-boot-maven-plugin version to 3.4.8
   - structured-logging version to 3.0.37
   - commons-lang3 version to 3.18.0 to resolve CVE-2025-48924