### PR TITLE
[CC-2765] Upgrade dependencies to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
     <properties>
         <java.version>21</java.version>
         <thymeleaf-layout-dialect.version>3.3.0</thymeleaf-layout-dialect.version>
-        <spring-boot-dependencies.version>3.4.8</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.4.8</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.4.9</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.4.9</spring-boot-maven-plugin.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <structured-logging.version>3.0.37</structured-logging.version>
@@ -132,12 +132,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.sonarsource.scanner.maven</groupId>
-            <artifactId>sonar-maven-plugin</artifactId>
-            <version>${sonar-maven-plugin.version}</version>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>


### PR DESCRIPTION
   - spring-boot-dependencies version to 3.4.9 to resolve CVE-2025-41242,CVE-2025-48989
   - spring-boot-maven-plugin version to 3.4.9
   - removed redundant sonar-maven-plugin dependency