### PR TITLE
the image is rendered already as svg via the class

### DIFF
--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,5 +1,4 @@
 <th:block th:with="
-            cdnUrl=${@environment.getProperty('cdn.url')},
             chsUrl=${@environment.getProperty('chs.url')}">
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
@@ -81,7 +80,6 @@
                     class="govuk-footer__link govuk-footer__copyright-logo"
                     data-event-id="crown-copyright-footer-link"
                     href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-                    th:style="'background-image: url(' + ${cdnUrl} + '/images/govuk-crest.png);'"
                     data-th-text="#{label.footer.crownCopyright}">
                 </a>
             </div>


### PR DESCRIPTION
As per title.
The image is rendered already as svg via the pseudo element built on the class
    `.govuk-footer__copyright-logo`
 (ex. with `v.5.11.0`:

```
    .govuk-footer__copyright-logo:before {
        content: "";
        display: block;
        width: 100%;
        padding-top: 112px;
        background-image: url(/images/govuk-frontend/v5.11.0/govuk-crest.svg);
        background-repeat: no-repeat;
        background-position: 50% 0;
        background-size: 125px 102px;
        text-align: center;
        white-space: nowrap
    }
```
)